### PR TITLE
Let lower case character > upper case character, as with ascii

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
         if (b == undefined) {
             b = 62;
         }
-        var base = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        var base = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
         var r = num % b;
         var res = base[r];
         var q = Math.floor(num / b);
@@ -25,7 +25,7 @@ module.exports = {
     	if (b == undefined) {
             b = 62;
         }
-        var base = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        var base = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
         var limit = (num + '').length;
         var res = base.indexOf(num[0]);
         for (var i = 1; i < limit; i++) {


### PR DESCRIPTION
It seems more intuitive to put upper case characters before lower case ones, similar to ASCII and Base64.
## 

Though Base64 puts 0-9 after A-Za-z (not in accordance with ASCII), I guess that's because Base64 is designed for some extent of obfuscation (0-9 is not mapped to 0-9, so it becomes more difficult to parse for human). E.g. basic access authentication use Base64.
